### PR TITLE
AI_OpenLock "<CreateProgress>b__8_1"

### DIFF
--- a/KarmaOnCaught/KarmaOnCaught/Patches/AIOpenLockPatch.cs
+++ b/KarmaOnCaught/KarmaOnCaught/Patches/AIOpenLockPatch.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using EModding.Helper;
+using HarmonyLib;
+
+namespace KarmaOnCaught.Patches;
+
+[HarmonyPatch]
+internal class AIOpenLockPatch
+{
+    private static KocConfig.Patch Config => KocConfig.Managed["Lockpick"];
+
+    internal static bool Prepare()
+    {
+        return Config.Enabled!.Value;
+    }
+
+    internal static MethodBase TargetMethod()
+    {
+        return AccessTools.Method(typeof(AI_OpenLock), "<CreateProgress>b__8_1");
+    }
+
+    [HarmonyTranspiler]
+    internal static IEnumerable<CodeInstruction> OnCrimeWitnessIl(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions)
+            .End()
+            .MatchEndBackwards(
+                new OperandContains(OpCodes.Callvirt, nameof(Point.TryWitnessCrime)))
+            .EnsureValid("pos.TryWitnessOpenLock")
+            .SetInstruction(
+                Transpilers.EmitDelegate(TryWitnessOpenLock))
+            .InstructionEnumeration();
+    }
+
+    private static bool TryWitnessOpenLock(Point pos, Chara cc, Chara? target, int radius, Func<Chara, bool>? func)
+    {
+        if (KocMod.SkipNext()) {
+            return false;
+        }
+
+        var difficulty = 0f;
+        var detection = Config.DetectionRadius!.Value;
+        var mod = Config.DifficultyModifier!.Value;
+        var skill = (cc.Evalue(SKILL.lockpicking) + cc.DEX) / 2f;
+
+        var witnesses = pos.ListWitnesses(cc, detection).Count;
+        var caught = pos.TryWitnessCrime(cc, radius: detection, funcWitness: w => {
+            var los = w.CanSee(cc) ? 50 : 0;
+            var perception = w.PER * (75 + los) / 100;
+
+            var randomCost = EClass.rndf(perception + mod);
+            difficulty += randomCost;
+
+            return randomCost > skill;
+        });
+
+        var suspicion = difficulty / (cc.DEX * witnesses + 1f);
+        KocMod.DoModKarma(caught, cc, -1, suspicion >= 0.65f, witnesses);
+        return caught;
+    }
+}


### PR DESCRIPTION
MapLevel 0 (Palmia)
default ,not nightly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a patch to AI lockpicking that replaces the witness check with a stat-based calculation and applies karma when caught. This makes detection depend on witnesses’ PER, line of sight, and the actor’s lockpicking/DEX.

- **New Features**
  - Replaces Point.TryWitnessCrime in AI_OpenLock.CreateProgress with a custom TryWitnessOpenLock via a transpiler.
  - Uses configurable detection radius and difficulty modifier from `KocConfig.Managed["Lockpick"]`; only runs when Enabled.
  - Skill check averages lockpicking and DEX; witness impact scales with PER and line of sight.
  - Computes suspicion and calls KocMod.DoModKarma when caught; respects SkipNext to prevent recursion.

<sup>Written for commit 47b7078f33b1aa0f79d0675deecade69fa353eca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gottyduke/Elin.Plugins/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

