### PR TITLE
Refactor method access in TaskDwarfPatch.cs

### DIFF
--- a/KarmaOnCaught/KarmaOnCaught/Patches/TaskDwarfPatch.cs
+++ b/KarmaOnCaught/KarmaOnCaught/Patches/TaskDwarfPatch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -19,9 +19,11 @@ internal class TaskDwarfPatch
         }
 
         OnModKarmaPatch.ToRemove.Add(
-            AccessTools.Method("TaskDig:<OnProgressComplete>g__Dig|22_0", [typeof(Point)]));
+            AccessTools.Method(typeof(TaskDig), nameof(TaskDig.OnProgressComplete)));
         OnModKarmaPatch.ToRemove.Add(
             AccessTools.Method(typeof(TaskMine), nameof(TaskMine.OnProgressComplete)));
+
+        OnModKarmaPatch.ToRemove.Add(AccessTools.Method(typeof(TaskDig), "<OnProgressComplete>g__Dig|22_0"));
 
         return true;
     }


### PR DESCRIPTION
Add "TaskDig:<OnProgressComplete>g__Dig|22_0"

It is unclear whether "TaskDig+<>c__DisplayClass19_0:<OnCreateProgress>b__1"
is still being used by the process.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored method lookups in TaskDwarfPatch to use typed reflection and ensure both TaskDig.OnProgressComplete and its compiler-generated local function <OnProgressComplete>g__Dig|22_0 are removed. This makes unpatching more reliable across compiler/name changes while keeping TaskMine behavior unchanged.

<sup>Written for commit b7e5625db9d48c87c2269116c1d8e94697751fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gottyduke/Elin.Plugins/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

